### PR TITLE
introduce notification and pushtoken types

### DIFF
--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -1,0 +1,63 @@
+import mongoose, { Types, Schema, Model } from 'mongoose';
+
+export interface INotification {
+  sourceUserId: Types.ObjectId; // ID of the user who triggered the notification
+  targetUserId: Types.ObjectId; // ID of the user who will receive the notification
+  type: 'message' | 'mention' | 'like' | 'reply'; // Type of notification
+  title: string; // Title of the notification
+  content: string; // Content of the notification
+  status: 'unread' | 'read'; // Status of the notification
+  createdAt?: Date; // Timestamp when the notification was created
+  updatedAt?: Date; // Timestamp when the notification was last updated
+  link?: string; // Optional link to redirect the user when they click the notification
+}
+
+export interface INotificationDocument
+  extends INotification,
+    mongoose.Document {}
+
+export const notificationSchema = new Schema<INotificationDocument>(
+  {
+    sourceUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    targetUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    type: {
+      type: String,
+      enum: ['message', 'mention', 'like', 'reply'],
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    content: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ['unread', 'read'],
+      default: 'unread',
+    },
+    link: {
+      type: String,
+      default: null,
+    },
+  },
+  {
+    timestamps: true, // Automatically handles createdAt and updatedAt
+  }
+);
+
+export const NotificationModel: Model<INotificationDocument> = mongoose.model(
+  'Notification',
+  notificationSchema
+);

--- a/src/types/PushToken.ts
+++ b/src/types/PushToken.ts
@@ -1,0 +1,34 @@
+import mongoose, { Model, Types, Document } from 'mongoose';
+
+export interface IPushToken {
+  userId: Types.ObjectId;
+  token: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface IPushTokenDocument extends IPushToken, Document {}
+
+export const pushTokenSchema = new mongoose.Schema<IPushTokenDocument>(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    token: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+  },
+  {
+    timestamps: true, // automatically handles createdAt and updatedAt
+  }
+);
+
+export const PushTokenModel: Model<IPushTokenDocument> = mongoose.model(
+  'PushToken',
+  pushTokenSchema
+);


### PR DESCRIPTION
The Push Token model will store the FCM tokens associated with the user.
The Notifications model will store the persistent notifications for the notifications store page. We can add a script later to purge old notifications and reduce DB congestion.